### PR TITLE
Fix builder check and unit test

### DIFF
--- a/RLatro.Test/CoreRules/HandEvaluationTest.cs
+++ b/RLatro.Test/CoreRules/HandEvaluationTest.cs
@@ -38,7 +38,7 @@ namespace RLatro.Test.CoreRules
             RoundState.HandleAction(new RoundAction()
             {
                 ActionIntent = RoundActionIntent.Play,
-                CardIndexes = Enumerable.Range(0, int.Min(cards.Length, 5)).Select(i => (byte)i).ToArray(),
+                CardIndexes = Enumerable.Range(0, Math.Min(cards.Length, 5)).Select(i => (byte)i).ToArray(),
             });
 
             Assert.That(RoundState.CurrentChipsScore, Is.EqualTo(expectedScore));

--- a/Rlatro.Core/GameEngine/GameStateController/GameContextBuilder.cs
+++ b/Rlatro.Core/GameEngine/GameStateController/GameContextBuilder.cs
@@ -91,11 +91,11 @@ namespace Balatro.Core.GameEngine.GameStateController
         
         public GameContext CreateGameContext()
         {
-            if (GameContext.Hand is null)
+            if (GameContext.Deck.Count == 0)
             {
-                throw new InvalidOperationException($"Provide a deck factory with {nameof(WithDeck)} is not set.");
+                throw new InvalidOperationException($"Provide a deck factory with {nameof(WithDeck)} before creating the context.");
             }
-            
+
             return GameContext;
         }
     }


### PR DESCRIPTION
## Summary
- fix missing deck validation in `GameContextBuilder`
- correct `Math.Min` usage in `HandEvaluationTest`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*