### PR TITLE
Fix unit test card index calculation

### DIFF
--- a/RLatro.Test/CoreRules/HandEvaluationTest.cs
+++ b/RLatro.Test/CoreRules/HandEvaluationTest.cs
@@ -39,7 +39,7 @@ namespace RLatro.Test.CoreRules
             RoundState.HandleAction(new RoundAction()
             {
                 ActionIntent = RoundActionIntent.Play,
-                CardIndexes = Enumerable.Range(0, int.Min(cards.Length, 5)).ToArray(),
+                CardIndexes = Enumerable.Range(0, Math.Min(cards.Length, 5)).ToArray(),
             });
 
             Assert.That(RoundState.CurrentChipsScore, Is.EqualTo(expectedScore));


### PR DESCRIPTION
## Summary
- fix HandEvaluationTest using `Math.Min`

## Testing
- `dotnet test` *(fails: Unable to restore packages)*